### PR TITLE
Use --clean now as --rm-dist is deprecated [semver:minor]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,8 +67,8 @@ workflows:
                 - "1.15.0"
                 - "1.15.2"
               go-version:
+                - "1.18.4"
                 - "1.19.5"
-                - "1.20"
               dry-run:
                 - true
       - gor/release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,10 +40,10 @@ workflows:
           orb-path: orb.yml
           requires:
             - orb-tools/lint
-          context: orbs
+          context: circleci-ctx
       - orb-tools/trigger-integration-tests-workflow:
           name: trigger-integration-dev
-          context: orbs
+          context: circleci-ctx
           requires:
             - orb-tools/publish-dev
   integration-test_deploy:
@@ -64,17 +64,17 @@ workflows:
                 - linux
                 - mac
               version:
-                - "1.3.0"
-                - "1.7.0"
+                - "1.15.0"
+                - "1.15.2"
               go-version:
-                - "1.17.7"
-                - "1.18"
+                - "1.19.5"
+                - "1.20"
               dry-run:
                 - true
       - gor/release:
           name: config-test
-          version: "1.7.0"
-          go-version: "1.18"
+          version: "1.15.2"
+          go-version: "1.19.5"
           dry-run: true
           config: "./.goreleaser-mac.yml"
       - orb-tools/dev-promote-prod-from-commit-subject:
@@ -89,8 +89,7 @@ workflows:
           filters:
             branches:
               only: trunk
-          context:
-            - orbs
+          context: circleci-ctx
   weekly-cron-wf:
     when:
       and:
@@ -104,7 +103,7 @@ workflows:
           orb-path: orb.yml
           requires:
             - orb-tools/lint
-          context: orbs
+          context: circleci-ctx
 
 
 jobs:
@@ -115,7 +114,7 @@ jobs:
     executor: <<parameters.runner>>
     steps:
       - gor/install:
-          version: "1.7.0"
+          version: "1.15.0"
       - run:
           name: "Try running GoReleaser"
           command: goreleaser --version

--- a/orb.yml
+++ b/orb.yml
@@ -79,7 +79,7 @@ commands:
     parameters:
       dry-run:
         description: |
-          Basically runs `goreleaser --snapshot --skip-publish --rm-dist` for
+          Basically runs `goreleaser --snapshot --skip-publish --clean` for
           you when true.
         type: boolean
         default: false
@@ -91,7 +91,7 @@ commands:
       - when:
           condition: <<parameters.dry-run>>
           steps:
-            - run: goreleaser --snapshot --skip-publish --rm-dist --config=<< parameters.config >>
+            - run: goreleaser --snapshot --skip-publish --clean --config=<< parameters.config >>
       - unless:
           condition: <<parameters.dry-run>>
           steps:
@@ -108,7 +108,7 @@ jobs:
         type: string
       dry-run:
         description: |
-          Basically runs `goreleaser --snapshot --skip-publish --rm-dist` for
+          Basically runs `goreleaser --snapshot --skip-publish --clean` for
           you when true.
         type: boolean
         default: false


### PR DESCRIPTION
`--rm-dist` has been deprecated as of GoReleaser v1.15.0. In a way, this is kind of a breaking change but I'm still going to do a minor release anyway since people should be following along with GoReleaser releases.

Use v2.1.x of this orb or lower if you're using a version of GoReleaser before v1.15.0. This change will be published in v2.2.0 of this orb.